### PR TITLE
Fixed fileNames typo and added "Dockerfile" to fileNames

### DIFF
--- a/icon-assignments.json
+++ b/icon-assignments.json
@@ -170,7 +170,7 @@
         "tex": "_tex",
         "tif": "_image"
     },
-    "filenames": {
+    "fileNames": {
         "opensees.exe": "_opensees",
         "openseesSP.exe": "_opensees",
         "openseesMP.exe": "_opensees"

--- a/icon-assignments.json
+++ b/icon-assignments.json
@@ -173,6 +173,7 @@
     "fileNames": {
         "opensees.exe": "_opensees",
         "openseesSP.exe": "_opensees",
-        "openseesMP.exe": "_opensees"
+        "openseesMP.exe": "_opensees",
+        "Dockerfile": "_docker"
     }
 }


### PR DESCRIPTION
Changed `filenames` to `fileNames` in icon-assignments.json, then added` "Dockerfile": "_docker"` to `fileNames`